### PR TITLE
Add s3 region to the example deploy.js

### DIFF
--- a/edd-cli/config/deploy.js
+++ b/edd-cli/config/deploy.js
@@ -33,7 +33,8 @@ module.exports = function(deployTarget) {
     ENV.s3 = {
       accessKeyId: process.env['AWS_ACCESS_KEY'],
       secretAccessKey: process.env['AWS_SECRET_KEY'],
-      bucket: 'edd-staging'
+      bucket: 'edd-staging',
+      region: 'us-east-1'
     };
   }
 
@@ -57,7 +58,8 @@ module.exports = function(deployTarget) {
     ENV.s3 = {
       accessKeyId: process.env['AWS_ACCESS_KEY'],
       secretAccessKey: process.env['AWS_SECRET_KEY'],
-      bucket: 'edd-production'
+      bucket: 'edd-staging',
+      region: 'us-east-1'
     }
   }
 


### PR DESCRIPTION
Following this https://github.com/ember-cli-deploy/ember-cli-deploy-s3/pull/24, region is no longer defaulting to us-east-1.