### PR TITLE
Improve consistency with redis index prefix

### DIFF
--- a/edd-cli/config/deploy.js
+++ b/edd-cli/config/deploy.js
@@ -9,7 +9,7 @@ module.exports = function(deployTarget) {
     };
 
     ENV.redis = {
-      keyPrefix: 'edd-cli',
+      keyPrefix: 'edd-cli:index',
       revisionKey: '__development__',
       allowOverwrite: true,
       host: 'localhost', // this can be omitted because it is the default
@@ -26,6 +26,7 @@ module.exports = function(deployTarget) {
     };
     // configure other plugins for staging deploy target here
     ENV.redis = {
+      keyPrefix: 'edd-cli:index',
       allowOverwrite: true,
       host: process.env['STAGING_HOST'],
       port: process.env['STAGING_PORT'],
@@ -51,6 +52,7 @@ module.exports = function(deployTarget) {
     };
 
     ENV.redis = {
+      keyPrefix: 'edd-cli:index',
       allowOverwrite: true,
       host: 'localhost',
       port: process.env['REDIS_PORT']

--- a/edd-rails/app/controllers/demo_controller.rb
+++ b/edd-rails/app/controllers/demo_controller.rb
@@ -3,7 +3,7 @@ class DemoController < ApplicationController
 
   def index
     index_key = if Rails.env.development?
-                  'edd-cli:__development__'
+                  'edd-cli:index:__development__'
                 elsif fetch_revision
                   "edd-cli:index:#{fetch_revision}"
                 else


### PR DESCRIPTION
After doing my own deployment, I noticed that Rails demo is looking for `edd-cli:index:<KEY>` but the _edd-cli/config/deploy.js_ script in the demo is only setting a prefix key in the development environment. This hotfix standardizes on the key prefix across the different environments.